### PR TITLE
Move `active` check out of the `kind` condition

### DIFF
--- a/src/jsx.js
+++ b/src/jsx.js
@@ -34,8 +34,9 @@ export default class JSX extends Component {
   }
 
   render() {
+    if (!this.props.active) return null;
+    
     if (
-      this.props.active &&
       typeof this.state.current !== 'undefined' &&
       typeof this.state[this.state.current.kind] !== 'undefined'
     ) {


### PR DESCRIPTION
https://github.com/storybooks/addon-jsx/pull/45/files Added an `active` prop check but placed it inside the condition which conditionally renders based on the kind of component. As a result, the disabled "Copy" button renders on all other add-on tabs, where JSX is "inactive".